### PR TITLE
How to specify target directory is revised

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algolia-uploader",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "command-line util to upload Algolia source",
   "type": "module",
   "exports": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ const main = defineCommand({
     try {
       const config = ConfigProvider.getInstance();
       let dataDir = config.getConfig("DATA_DIR");
-      dataDir = path.join(process.cwd(), "..", dataDir);
+      dataDir = path.join(process.cwd(), dataDir);
       const dirExists =
         fs.existsSync(dataDir) && fs.statSync(dataDir).isDirectory();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ const main = defineCommand({
     try {
       const config = ConfigProvider.getInstance();
       let dataDir = config.getConfig("DATA_DIR");
-      dataDir = path.join(__dirname, "..", dataDir);
+      dataDir = path.join(process.cwd(), "..", dataDir);
       const dirExists =
         fs.existsSync(dataDir) && fs.statSync(dataDir).isDirectory();
 


### PR DESCRIPTION
## What's changed
- [x]  `process.cwd()` is used instead of `__dirname`, it is only available with `CommonJs`