### PR TITLE
fixed counting updated items count

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algolia-uploader",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "command-line util to upload Algolia source",
   "type": "module",
   "exports": {

--- a/src/utils/Uploader.ts
+++ b/src/utils/Uploader.ts
@@ -41,19 +41,23 @@ export class Uploader {
     const sortedNewObjs = normalizeIndexedItemArray(newObjects);
     const operations = this.determineOperations(existingObjects, sortedNewObjs);
 
-    if (operations.update.length === 0 && operations.add.length === 0) {
+    if (
+      operations.update.length === 0 &&
+      operations.add.length === 0 &&
+      operations.delete.length === 0
+    ) {
       console.log("No updates needed. All objects are up to date.");
       return;
     }
 
     // Update Operation
     if (operations.update.length > 0) {
-      const res = await this.client.partialUpdateObjects({
+      const res: BatchResponse[] = await this.client.partialUpdateObjects({
         indexName: this.indexName,
         objects: operations.update,
         createIfNotExists: true,
       });
-      console.log(`Updated ${res.length} objects`);
+      console.log(`Updated ${res[0].objectIDs.length} objects`);
     }
 
     // Add Operation
@@ -62,7 +66,7 @@ export class Uploader {
         indexName: this.indexName,
         objects: operations.add,
       });
-      console.log(`Added ${res.length} objects`);
+      console.log(`Added ${res[0].objectIDs.length} objects`);
     }
 
     // Delete Operation
@@ -72,7 +76,7 @@ export class Uploader {
         indexName: this.indexName,
         objectIDs: targetIds,
       });
-      console.log(`Deleted ${res.length} objects`);
+      console.log(`Deleted ${res[0].objectIDs.length} objects`);
     }
   }
 

--- a/test/Uploader.test.ts
+++ b/test/Uploader.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi, beforeEach } from "vitest";
-import { SearchClient, BrowseResponse, BatchResponse } from "algoliasearch";
+import { SearchClient, BrowseResponse } from "algoliasearch";
 import IndexedItem from "src/types/IndexedItem";
 import { AlgoliaClientProvider } from "src/utils/AlgoliaClientProvider";
 import { Uploader } from "src/utils/Uploader";
@@ -19,9 +19,15 @@ class MockAlgoliaClient {
     },
   );
 
-  partialUpdateObjects = vi.fn(async () => Promise.resolve({ length: 2 }));
-  saveObjects = vi.fn(async () => Promise.resolve({ length: 1 }));
-  deleteObjects = vi.fn(async () => Promise.resolve([{ length: 1 }]));
+  partialUpdateObjects = vi.fn(async () =>
+    Promise.resolve([{ objectIDs: ["prod_001"] }]),
+  );
+  saveObjects = vi.fn(async () =>
+    Promise.resolve([{ objectIDs: ["prod_001"] }]),
+  );
+  deleteObjects = vi.fn(async () =>
+    Promise.resolve([{ objectIDs: ["prod_001"] }]),
+  );
 }
 
 describe("Uploader", () => {


### PR DESCRIPTION
This PR is revision for #10 .

## What's changed
When counting items updated/added/deleted, the count of the result: `res.length` was handled as the number of the items.
Now, `res[0].objectIDs.length` can properly count the number of items.

### Caution
It is not possible to know the number of items that could not be updated/added/deleted on the Algolia side using current response: `res`.