### PR TITLE
chore: change publish trigger from tag push to release published event

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Secure Publish to npm
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  release:
+    types: [published]
 
 permissions:
   id-token: write  # Required for OIDC
@@ -52,14 +51,6 @@ jobs:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
-
-      # Ensure npm 11.5.1 or later is installed
-      - name: Update npm
-        run: npm install -g npm@latest
-
-      # Ensure npm 11.5.1 or later is installed
-      - name: Update npm
-        run: npm install -g npm@latest
 
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm


### PR DESCRIPTION
## Summary
The publish workflow trigger is updated from tag push to GitHub Release published event

## Changes
- Changed trigger from push to release: [published]
- Duplicate npm install command is removed