### PR TITLE
docs(publishing): split and update release flow guide

### DIFF
--- a/.github/PUBLISHING.en.md
+++ b/.github/PUBLISHING.en.md
@@ -9,6 +9,8 @@ Before using the publish flow, configure the GitHub Actions settings required by
 
 - Create a repository Environment named `publish`.
   - GitHub: Settings → Environments → New environment
+- Configure npm Trusted Publishing (OIDC) for this GitHub repository/workflow.
+- No npm token secret is required.
 
 ## Goal
 

--- a/.github/PUBLISHING.en.md
+++ b/.github/PUBLISHING.en.md
@@ -1,0 +1,73 @@
+# npm Publishing Operations Guide (English)
+
+This file tracks the publishing process in English.
+For the Japanese version, see `.github/PUBLISHING.md`.
+
+## Goal
+
+- Release without direct pushes to `main`.
+- Keep `package.json` version and Git tag aligned.
+- Trigger npm publish from GitHub Release.
+
+## Current Standard Flow
+
+1. Create a release branch from `dev`.
+   - Example: `release/v0.0.13`
+2. Bump version on the release branch only.
+   - `npm version 0.0.13 --no-git-tag-version`
+3. Open a PR from the release branch to `dev`.
+4. Open a PR from `dev` to `main`.
+5. After merge to `main`, create a tag on the target commit.
+   - Example: `v0.0.13`
+6. Publish a GitHub Release to trigger the publish workflow.
+
+## Command Example
+
+### 1) Release branch and version bump
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b release/v0.0.13
+npm version 0.0.13 --no-git-tag-version
+git add package.json package-lock.json
+git commit -m "chore(release): 0.0.13"
+git push -u origin release/v0.0.13
+```
+
+### 2) Open pull requests
+
+```bash
+gh pr create --base dev --head release/v0.0.13 --title "chore(release): 0.0.13"
+gh pr create --base main --head dev --title "dev"
+```
+
+### 3) Tag and Release after merge to main
+
+```bash
+git checkout main
+git pull origin main
+git tag -a v0.0.13 -m "v0.0.13"
+git push origin v0.0.13
+gh release create v0.0.13 --target main --title "v0.0.13" --generate-notes
+```
+
+## v0.0.13 Execution Record (Reference)
+
+- `release/v0.0.13 -> dev`: PR #139
+- `dev -> main`: PR #140
+- tag/release: `v0.0.13`
+- publish workflow: success
+
+## Operational Notes
+
+- `npm version patch` normally creates a tag automatically; use `--no-git-tag-version` on release branches.
+- Do not use `gh pr merge --delete-branch` on `dev -> main` PRs.
+  - It can unintentionally delete the `dev` branch.
+- Always create the release tag on the exact `main` commit to be published.
+
+## Troubleshooting Checklist
+
+- Is the GitHub Release created?
+- Did the `publish.yml` workflow start from the `release` event?
+- Did the tag/version consistency check pass?

--- a/.github/PUBLISHING.en.md
+++ b/.github/PUBLISHING.en.md
@@ -68,6 +68,7 @@ gh release create v0.0.13 --target main --title "v0.0.13" --generate-notes
 
 ## Troubleshooting Checklist
 
-- Is the GitHub Release created?
+- Is the GitHub Release published (not left as a draft)?
+- Does the tag name match the `vX.Y.Z` format (e.g., `v0.0.13`)?
 - Did the `publish.yml` workflow start from the `release` event?
 - Did the tag/version consistency check pass?

--- a/.github/PUBLISHING.en.md
+++ b/.github/PUBLISHING.en.md
@@ -3,6 +3,13 @@
 This file tracks the publishing process in English.
 For the Japanese version, see `.github/PUBLISHING.md`.
 
+## Prerequisites
+
+Before using the publish flow, configure the GitHub Actions settings required by `publish.yml`.
+
+- Create a repository Environment named `publish`.
+  - GitHub: Settings → Environments → New environment
+
 ## Goal
 
 - Release without direct pushes to `main`.

--- a/.github/PUBLISHING.md
+++ b/.github/PUBLISHING.md
@@ -3,6 +3,13 @@
 このファイルは、日本語での公開手順を管理します。
 英語版は `.github/PUBLISHING.en.md` を参照してください。
 
+## 事前準備
+
+`publish.yml` は GitHub Actions の `publish` Environment で実行される前提です。
+
+- GitHub repository の Settings で Environment 名 `publish` を作成してください。
+  - GitHub: Settings → Environments → New environment
+
 ## 目的
 
 - main への直接 push を行わず、PR ベースでリリースする。

--- a/.github/PUBLISHING.md
+++ b/.github/PUBLISHING.md
@@ -9,6 +9,8 @@
 
 - GitHub repository の Settings で Environment 名 `publish` を作成してください。
   - GitHub: Settings → Environments → New environment
+- npm 側で GitHub Actions 向けの Trusted Publishing（OIDC）を設定してください。
+- npm token secret は不要です。
 
 ## 目的
 

--- a/.github/PUBLISHING.md
+++ b/.github/PUBLISHING.md
@@ -1,62 +1,73 @@
-# 安全な npm publishing 手順
+# npm 公開運用ガイド（日本語）
 
-このドキュメントは、CI（GitHub Actions）を使って npm パッケージを安全に自動公開する運用手順をまとめたものです。
+このファイルは、日本語での公開手順を管理します。
+英語版は `.github/PUBLISHING.en.md` を参照してください。
 
-目的
+## 目的
 
-- パッケージ公開時のサプライチェーンリスクを低減すること。
+- main への直接 push を行わず、PR ベースでリリースする。
+- `package.json` のバージョンと Git タグを一致させる。
+- GitHub Release をトリガーに npm publish を実行する。
 
-基本方針
+## 現在の標準フロー
 
-- 公開トリガーは `タグ (v*.*.*)` のプッシュのみとする。
-- npm の発行トークンは `Automation token` を使用し、最小権限（publish のみ）・有効期限を設定する。
-- トークンは GitHub の `Environment`（例: `publish`）に登録し、必要に応じて承認者を設定する。
-- CI ワークフローは必ずテスト・lint・依存性チェックを通過させてから publish する。
+1. `dev` からリリースブランチを作成する。
+   - 例: `release/v0.0.13`
+2. リリースブランチでバージョンだけを更新する。
+   - `npm version 0.0.13 --no-git-tag-version`
+3. リリースブランチを `dev` にPRする。
+4. `dev` を `main` にPRする。
+5. `main` 反映後に `main` の対象コミットへタグを作成する。
+   - 例: `v0.0.13`
+6. GitHub Release を公開し、publish workflow を起動する。
 
-手順
+## 実行コマンド例
 
-1. npm 側で Automation token を作成
+### 1) リリースブランチ作成〜version更新
 
-- npm (https://www.npmjs.com/) にログイン
-- Profile → Access Tokens → Create New Token
-- Type: Automation
-- Permissions: Publish（最小）
-- Expiration: 可能なら短期（例: 30〜90日）を設定
-- トークンは一度しか表示されないので、安全に控えてください。
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b release/v0.0.13
+npm version 0.0.13 --no-git-tag-version
+git add package.json package-lock.json
+git commit -m "chore(release): 0.0.13"
+git push -u origin release/v0.0.13
+```
 
-2. GitHub に `Environment` を作成してシークレットを登録
+### 2) PR作成
 
-- リポジトリ → Settings → Environments → New environment → `publish`
-- Environment に `NPM_AUTOMATION_TOKEN` を追加（値は npm で作成したトークン）
-- 必要であれば `Required reviewers` を設定して、ワークフロー実行時に承認を必須にする
+```bash
+gh pr create --base dev --head release/v0.0.13 --title "chore(release): 0.0.13"
+gh pr create --base main --head dev --title "dev"
+```
 
-3. ブランチ・タグ戦略
+### 3) main反映後のタグ・Release
 
-- 公開はタグ `vX.Y.Z` の作成のみで行う
-- タグは main など保護されたブランチからのみ作成する（ブランチ保護ルールで PR レビューを必須にする）
+```bash
+git checkout main
+git pull origin main
+git tag -a v0.0.13 -m "v0.0.13"
+git push origin v0.0.13
+gh release create v0.0.13 --target main --title "v0.0.13" --generate-notes
+```
 
-4. ワークフローでの安全チェック（ワークフロー内で実装済み）
+## v0.0.13 実施履歴（参考）
 
-- `npm ci`（lockfile 使用）
-- `npm test`（ユニット/統合テスト）
-- `npm audit`（重大な脆弱性の検出）
-- タグと `package.json` のバージョン一致の検証
+- `release/v0.0.13 -> dev`: PR #139
+- `dev -> main`: PR #140
+- tag/release: `v0.0.13`
+- publish workflow: success
 
-5. 署名・証跡（オプション推奨）
+## 運用注意
 
-- より高い保証のため、ビルド成果物（`npm pack`で作成される tarball）を Sigstore/cosign で署名し、署名と provenance を GitHub Release に添付することを検討してください。
+- `npm version patch` は通常タグも同時作成するため、リリースブランチでは `--no-git-tag-version` を使う。
+- `gh pr merge --delete-branch` は `dev -> main` PR に使わない。
+  - `dev` ブランチ削除を招く可能性があるため。
+- タグは `main` の公開対象コミットに対して作成する。
 
-運用上の注意
+## 失敗時の確認ポイント
 
-- トークンは短期に設定し、定期ローテーションを行ってください。
-- トークンは個人アカウントではなく bot アカウントや organization 管理アカウントで発行することを推奨します。
-- 発行前に CI 成果物の内容を目視/自動チェックで確認できる仕組みを持ってください。
-
-トラブルシュート
-
-- ワークフローが `NPM_AUTOMATION_TOKEN` にアクセスできない場合は、ジョブが `environment: publish` を指定しているか確認してください。
-- publish が失敗した場合は、まずワークフローのログを確認し、`npm publish` のエラーメッセージを確認してください。
-
----
-
-このドキュメントはワークフローの補助としてリポジトリに置きます。運用ルールは組織ポリシーに合わせて調整してください。
+- Release は作成されたか。
+- `publish.yml` の workflow run が `release` イベントで起動しているか。
+- `tag` と `package.json version` の一致チェックで失敗していないか。

--- a/.github/PUBLISHING.md
+++ b/.github/PUBLISHING.md
@@ -68,6 +68,7 @@ gh release create v0.0.13 --target main --title "v0.0.13" --generate-notes
 
 ## 失敗時の確認ポイント
 
-- Release は作成されたか。
+- GitHub Release は公開済みか（Draft のままではないか）。
+- タグ名が `vX.Y.Z` 形式（例: `v0.0.13`）になっているか。
 - `publish.yml` の workflow run が `release` イベントで起動しているか。
 - `tag` と `package.json version` の一致チェックで失敗していないか。

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,6 @@ jobs:
         run: npm pack
 
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
         run: |
+          # Uses npm trusted publishing (OIDC), so no npm token secret is required.
           npm publish --provenance --access public

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS Guide
+
+This file helps coding agents be productive in this repository.
+
+## Project Snapshot
+
+- TypeScript CLI tool for syncing JSON data to Algolia.
+- Entry point: [src/index.ts](src/index.ts)
+- Core upload logic: [src/utils/Uploader.ts](src/utils/Uploader.ts)
+- Data shape and validation: [src/types/IndexedItem.ts](src/types/IndexedItem.ts)
+
+## Docs Index
+
+AGENTS.md is an index file; keep details in docs/\* and link from here.
+
+- Repository structure details: [docs/PROJECT_STRUCTURE.md](docs/PROJECT_STRUCTURE.md)
+- Team working rules: [docs/WORKING_RULES.md](docs/WORKING_RULES.md)
+- Release and publishing references: [docs/RELEASE_PUBLISHING.md](docs/RELEASE_PUBLISHING.md)
+
+## Fast Commands
+
+- Install deps: npm install
+- Build: npm run build
+- Test: npm test
+- Format: npm run lint
+- Local run: npm run dev
+
+## Required Environment
+
+The runtime requires all of these variables:
+
+- ALGOLIA_APP_ID
+- ALGOLIA_ADMIN_API_KEY
+- ALGOLIA_INDEX_NAME
+- DATA_DIR
+
+See setup details in [README.md](README.md).
+
+## CI and Hooks
+
+- Pre-commit runs lint-staged: [.husky/pre-commit](.husky/pre-commit)
+- Pre-push runs tests: [.husky/pre-push](.husky/pre-push)
+- CI test workflow: [.github/workflows/test.yml](.github/workflows/test.yml)
+
+## Pitfalls
+
+- DATA_DIR must point to an existing directory.
+- Only JSON inputs are read by the loader utility.
+- Version/tag consistency is validated in the publish workflow.
+- This repo uses npm trusted publishing (OIDC); npm token secrets are not required for publish.

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -1,0 +1,43 @@
+# Project Structure
+
+This document provides a directory-level map of the repository.
+`AGENTS.md` should stay concise and link here for structure details.
+
+## Top-Level
+
+- `.github/`: CI workflows and release/publishing documentation.
+- `.husky/`: Git hooks for pre-commit and pre-push checks.
+- `src/`: Application source code.
+- `test/`: Vitest test suites.
+- `docs/`: Supporting project documentation for agent and contributor indexing.
+- `README.md`: Usage and environment setup.
+- `package.json`: Scripts, dependencies, and lint-staged config.
+- `build.config.ts`: `unbuild` build output configuration.
+- `vitest.config.ts`: Test configuration.
+- `tsconfig.json`: TypeScript compiler settings.
+
+## Source Layout
+
+- `src/index.ts`: CLI entry point and orchestration.
+- `src/types/`
+  - `IndexedItem.ts`: Data shape, type guard, and normalization.
+  - `Operations.ts`: Operation model for add/update/delete handling.
+- `src/utils/`
+  - `ConfigProvider.ts`: Environment configuration singleton.
+  - `AlgoliaClientProvider.ts`: Algolia client/index singleton.
+  - `Uploader.ts`: Diff and upload execution logic.
+  - `readAllJsonFiles.ts`: JSON source loader.
+
+## Test Layout
+
+- `test/ConfigProvider.test.ts`: Config singleton behavior.
+- `test/AlgoliaClientProvider.test.ts`: Algolia provider behavior.
+- `test/Uploader.test.ts`: Upload operation scenarios.
+- `test/normalizeIndexedItem.test.ts`: Normalization and deterministic ordering checks.
+
+## Related References
+
+- Japanese publishing guide: `.github/PUBLISHING.md`
+- English publishing guide: `.github/PUBLISHING.en.md`
+- Publish workflow: `.github/workflows/publish.yml`
+- Test workflow: `.github/workflows/test.yml`

--- a/docs/RELEASE_PUBLISHING.md
+++ b/docs/RELEASE_PUBLISHING.md
@@ -1,0 +1,14 @@
+# Release and Publishing
+
+This document indexes release and publishing references.
+`AGENTS.md` should link here instead of embedding release operation details.
+
+## References
+
+- Japanese guide: `.github/PUBLISHING.md`
+- English guide: `.github/PUBLISHING.en.md`
+- Publish workflow: `.github/workflows/publish.yml`
+
+## Rule
+
+- Follow the documented PR-based release flow instead of ad-hoc tagging.

--- a/docs/WORKING_RULES.md
+++ b/docs/WORKING_RULES.md
@@ -1,0 +1,42 @@
+# Working Rules
+
+This document defines team-level implementation and git operation policy.
+`AGENTS.md` should only index this file instead of duplicating detailed rules.
+
+## Implementation Policy
+
+- Use test-driven development (TDD): write or update tests first, then implement the minimum code to pass.
+
+## Commit Message Policy
+
+- Use Conventional Commits for all commits.
+- Recommended format: `type(scope): summary`
+- Example: `docs(publishing): clarify trusted publishing prerequisites`
+
+## Branch Strategy for New Features
+
+- When implementing new features, create a feature branch from `dev`.
+- Do not start new feature branches from `main`.
+
+## Review Before Push
+
+- If the push includes a moderately large feature, perform review before pushing.
+- Review must include at least:
+  - scope and requirement alignment
+  - tests added/updated and test results
+  - risk/regression checks
+
+## Design and Implementation Best Practices
+
+- Prefer small, focused changes over broad refactors.
+- Keep functions single-purpose and side effects explicit.
+- Validate external input early and fail fast with actionable error messages.
+- Preserve deterministic behavior (stable ordering and repeatable results).
+- Use explicit types and avoid introducing new `any` unless absolutely necessary at boundaries.
+- Reuse existing patterns before adding new abstractions.
+- Cover both happy path and error/edge cases when behavior changes.
+- Keep PR scope coherent: do not mix unrelated cleanup with feature work.
+
+## Notes
+
+- For release-specific branch flow, follow `.github/PUBLISHING.md` and `.github/PUBLISHING.en.md`.


### PR DESCRIPTION
Update publishing documentation based on the latest v0.0.13 release work.\n\n- rewrite Japanese guide with current PR-based release flow\n- add English guide as a separate file\n- document operational cautions and troubleshooting