### PR TITLE
docs(github): add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Overview
+
+<!-- Briefly describe the purpose of this pull request. -->
+
+## Changes
+
+<!-- List the main changes made in this pull request. -->
+
+## Related Issues
+
+<!-- Link related issues (e.g., Closes #123, Related #456). -->
+
+## Checklist
+
+- [ ] I have followed the code style guidelines
+- [ ] I have performed a self-review of my code
+- [ ] I have updated the documentation (if necessary)
+- [ ] I have added appropriate labels to this pull request
+
+## Additional Comments
+
+<!-- Add any extra notes, context, or concerns. -->


### PR DESCRIPTION
## Overview

Add a default GitHub pull request template for consistent PR descriptions.

## Changes

- add .github/PULL_REQUEST_TEMPLATE.md
- include sections: Overview, Changes, Related Issues, Checklist, Additional Comments

## Related Issues

N/A

## Checklist

- [x] I have followed the code style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated the documentation (if necessary)
- [x] I have added appropriate labels to this pull request

## Additional Comments

This introduces the repository-wide default PR template.