### PR TITLE
fix: run explicit build in publish workflow before packaging (v0.0.14)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  verify:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -35,7 +35,7 @@ jobs:
         run: npm audit --audit-level=high || true
 
   publish:
-    needs: build
+    needs: verify
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: publish
@@ -69,6 +69,15 @@ jobs:
           if [ "${TAG_VERSION}" != "${PKG_VERSION}" ]; then
             echo "Tag (${TAG_NAME}) normalized to (${TAG_VERSION}) does not match package.json version (${PKG_VERSION})"; exit 1
           fi
+
+      - name: Build for publish
+        run: npm run build
+
+      - name: Verify dist artifacts
+        run: |
+          ls -la dist
+          test -f dist/index.mjs
+          test -f dist/index.cjs
 
       - name: Pack (sanity)
         run: npm pack

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "algolia-uploader",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "algolia-uploader",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "ISC",
       "dependencies": {
         "algoliasearch": "^5.50.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algolia-uploader",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "command-line util to upload Algolia source",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Fixes the issue where `npm publish` produced only 3 files because `ignore-scripts=true` in `.npmrc` prevented `prepack` (unbuild) from running in CI.

## Changes

- Rename `build` job → `verify` (audit only; the old name was misleading)
- Add **Build for publish** step (`npm run build`) in the `publish` job before pack/publish
- Add **Verify dist artifacts** step to fail early if `dist/index.mjs` / `dist/index.cjs` are missing
- Bump version to 0.0.14

## Root cause

`.npmrc` sets `ignore-scripts=true`, which skips lifecycle scripts including `prepack`.  
On a clean CI runner, `dist/` does not exist, so the published tarball contained only `LICENSE`, `README.md`, and `package.json`.