### PR TITLE
chore(release): 0.0.15-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "algolia-uploader",
-  "version": "0.0.15-beta.1",
+  "version": "0.0.15-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "algolia-uploader",
-      "version": "0.0.15-beta.1",
+      "version": "0.0.15-beta.2",
       "license": "ISC",
       "dependencies": {
         "algoliasearch": "^5.52.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algolia-uploader",
-  "version": "0.0.15-beta.1",
+  "version": "0.0.15-beta.2",
   "description": "command-line util to upload Algolia source",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- bump package version to 0.0.15-beta.2 on release branch
- prepare prerelease promotion flow through dev and main

## Notes
- follows main-first release policy