### PR TITLE
sync: promote 0.0.15-beta.2 from dev to main

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -18,6 +18,17 @@ Before using the publish flow, configure the GitHub Actions settings required by
 - Trigger npm publish from GitHub Release.
 - Keep stable releases on npm `latest` and pre-releases on npm `next`.
 
+## Release Policy (Main-First)
+
+- Do not push release version bumps directly to `dev`.
+- Always use a dedicated release branch from `dev`.
+   - Examples: `release/v0.0.15`, `release/v0.0.15-beta.1`
+- Merge flow for every release:
+   1. `release/*` -> `dev`
+   2. `dev` -> `main`
+   3. Create tag and GitHub Release from the target commit on `main`
+- The publishing workflow is triggered from the GitHub Release for that `main` tag.
+
 ## npm Distribution Tag Behavior
 
 - Stable versions (for example `0.0.15`) are published with npm dist-tag `latest`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "algolia-uploader",
-  "version": "0.0.15-beta.1",
+  "version": "0.0.15-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "algolia-uploader",
-      "version": "0.0.15-beta.1",
+      "version": "0.0.15-beta.2",
       "license": "ISC",
       "dependencies": {
         "algoliasearch": "^5.52.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algolia-uploader",
-  "version": "0.0.15-beta.1",
+  "version": "0.0.15-beta.2",
   "description": "command-line util to upload Algolia source",
   "repository": {
     "type": "git",

--- a/src/utils/ConfigProvider.ts
+++ b/src/utils/ConfigProvider.ts
@@ -1,3 +1,5 @@
+import "@dotenvx/dotenvx/config";
+
 // variable to make complementary works
 const REQUIRED_ENV_VARS = {
   ALGOLIA_APP_ID: "ALGOLIA_APP_ID",


### PR DESCRIPTION
## Summary
- promote beta release version 0.0.15-beta.2 to main
- keep release flow main-first before tagging and GitHub prerelease
