### PR TITLE
chore(release): 0.0.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "algolia-uploader",
-  "version": "0.0.16",
+  "version": "0.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "algolia-uploader",
-      "version": "0.0.16",
+      "version": "0.0.18",
       "license": "ISC",
       "dependencies": {
         "algoliasearch": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algolia-uploader",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "command-line util to upload Algolia source",
   "repository": {
     "type": "git",
@@ -61,11 +61,5 @@
   "exports": {
     ".": "./dist/index.mjs",
     "./package.json": "./package.json"
-  },
-  "inlinedDependencies": {
-    "@dotenvx/dotenvx": "2.14.0",
-    "@dotenvx/primitives": "2.1.0",
-    "@dotenvx/tooling": "1.0.2",
-    "picomatch": "4.0.5"
   }
 }


### PR DESCRIPTION
## Summary
- Bump package version to 0.0.18

## Background
v0.0.17 was tagged but never published to npm because the publish job failed on an incompatible npm version. That fix landed in #255, so 0.0.18 is the first version released through the corrected flow.

## Verification
- npm test
- npm run build